### PR TITLE
chore(deps-dev): bump @types/node from 18.0.0 to 20.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
       },
       "devDependencies": {
         "@heavy-division/eslint-config": "^0.1.0",
-        "@types/node": "^18.0.0",
+        "@types/node": "^20.4.5",
         "@typescript-eslint/eslint-plugin": "^4.28.5",
         "@typescript-eslint/parser": "^4.28.5",
         "dotenv": "^16.0.0",
@@ -523,9 +523,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -6618,9 +6618,9 @@
       }
     },
     "@types/node": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
-      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA=="
+      "version": "20.4.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.5.tgz",
+      "integrity": "sha512-rt40Nk13II9JwQBdeYqmbn2Q6IVTA5uPhvSO+JVqdXw/6/4glI6oR9ezty/A9Hg5u7JH4OmYmuQ+XvjKm0Datg=="
     },
     "@types/responselike": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@heavy-division/eslint-config": "^0.1.0",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.4.5",
     "@typescript-eslint/eslint-plugin": "^4.28.5",
     "@typescript-eslint/parser": "^4.28.5",
     "dotenv": "^16.0.0",


### PR DESCRIPTION
### Description

In this pull request, the `@types/node` package version is being updated from `18.0.0` to `20.4.5` in both the `package.json` and `package-lock.json` files.

- Update `@types/node` package version from `18.0.0` to `20.4.5` in both `package.json` and `package-lock.json` files.

These changes are necessary to keep the project dependencies up to date and aligned with the latest versions.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Bump the `@types/node` development dependency version from 18.0.0 to 20.4.5 in the `package.json` file.

### Why are these changes being made?

This update ensures compatibility with the latest Node.js features and improvements, providing better type definitions and support for the development environment. Keeping dependencies up-to-date is crucial for maintaining security and leveraging new functionalities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->